### PR TITLE
Add support for JS template backtick ` literals

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -27,7 +27,7 @@ export function decorate() {
     let noCommentText = replaceComments(allText)
 
     let rainbows = colors.map(x => vscode.window.createTextEditorDecorationType({ color: x }))
-    let regex = /(?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)')/g;
+    let regex = /(?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)')|`([^`\\]*(?:\\.[^`\\]*)*)`)/g;
     let decorators = colors.map(color => [])
     let match: RegExpMatchArray;
     let offset: number = getRandomInt(0, colors.length);


### PR DESCRIPTION
This closes #11 and would add support for JavaScript template literals, so the characters matched would be ", ', and `